### PR TITLE
Add ability to provide iam roles SNS:ListSubscriptionsByTopic

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -33,3 +33,9 @@ variable "sns_kms_encryption" {
   default     = false
   description = "Enabled KMS CMK encryption at rest for SNS Topic"
 }
+
+variable "list_subscription_roles" {
+  type = list(string)
+  default = []
+  description = "Roles to allow SNS:ListSubscriptionsByTopic"
+}

--- a/sns-topic.tf
+++ b/sns-topic.tf
@@ -43,4 +43,23 @@ data "aws_iam_policy_document" "sns" {
     resources = [aws_sns_topic.default[0].arn]
     sid       = "allow-publish-event-bridge"
   }
+
+  statement {
+    actions = [
+      "SNS:ListSubscriptionsByTopic"
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = var.list_subscription_roles
+    }
+
+    resources = [
+      aws_sns_topic.default.arn,
+    ]
+
+    sid = "allow-drata-to-monitor"
+  }
 }


### PR DESCRIPTION
Fixes drift in the MGMT services repo by updating this module to allow us to set arbitrary roles that can list subscriptions on the topic. This is needed as we have to allow Drata to verify that we have subscriptions on our alert topics.